### PR TITLE
Update build-listing.yml

### DIFF
--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -31,15 +31,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       
-      - uses: actions/checkout@v3 # check out this repo
-      - uses: actions/checkout@v3 # check out automation repo
+      - uses: actions/checkout@v4 # check out this repo
+      - uses: actions/checkout@v4 # check out automation repo
         with:
           repository: pimaker/package-list-action
           path: ${{env.pathToCi}}
           clean: false # otherwise the local repo will no longer be checked out
           
       - name: Restore Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{env.pathToCi}}/.nuke/temp
@@ -52,13 +52,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ${{env.listPublishDirectory}}
           
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
GitHub has deprecated several actions which we used in our template-package and template-package-listing repositories. These actions will start to fail after January 30, 2025.

As per VRChat's announcement, updates to GitHub Actions workflow are:

* Updated `actions/checkout` to v4 for both the repository and automation repo checkouts.
* Updated `actions/cache` to v4 for restoring cache.
* Updated `actions/configure-pages` to v5 for setting up pages.
* Updated `actions/upload-pages-artifact` to v3 for uploading artifacts.
* Updated `actions/deploy-pages` to v4 for deploying to GitHub Pages.